### PR TITLE
KeyboardInput gefixt, Nummerntasten konsequent genutzt

### DIFF
--- a/OctoAwesome/OctoAwesome.Client/Components/Input/KeyboardInput.cs
+++ b/OctoAwesome/OctoAwesome.Client/Components/Input/KeyboardInput.cs
@@ -85,7 +85,7 @@ namespace OctoAwesome.Client.Components.Input
             ApplyTrigger.Value = keyboardState.IsKeyDown(Keys.Q);
             InventoryTrigger.Value = keyboardState.IsKeyDown(Keys.I) || keyboardState.IsKeyDown(Keys.Tab);
             JumpTrigger.Value = keyboardState.IsKeyDown(Keys.Space);
-            SlotTrigger[0].Value = keyboardState.IsKeyDown(Keys.NumPad1);
+            SlotTrigger[0].Value = keyboardState.IsKeyDown(Keys.D1);
             SlotTrigger[1].Value = keyboardState.IsKeyDown(Keys.D2);
             SlotTrigger[2].Value = keyboardState.IsKeyDown(Keys.D3);
             SlotTrigger[3].Value = keyboardState.IsKeyDown(Keys.D4);

--- a/OctoAwesome/OctoAwesome.Client/Components/SimulationComponent.cs
+++ b/OctoAwesome/OctoAwesome.Client/Components/SimulationComponent.cs
@@ -58,7 +58,7 @@ namespace OctoAwesome.Client.Components
             string filename = "player.info";
 
             if (!File.Exists(root.FullName + Path.DirectorySeparatorChar + filename))
-                return null;
+                return new Player();
 
             using (Stream stream = File.Open(root.FullName + Path.DirectorySeparatorChar + filename, FileMode.Open, FileAccess.Read))
             {


### PR DESCRIPTION
Ein Bug im KeyboardInput: Jetzt kann auch der erste Blocktyp über die D-Nummerntasten (über den Buchstaben) ausgewählt werden.