### PR TITLE
OrientationFlags als byte

### DIFF
--- a/OctoAwesome/OctoAwesome/OrientationFlags.cs
+++ b/OctoAwesome/OctoAwesome/OrientationFlags.cs
@@ -9,7 +9,7 @@ namespace OctoAwesome
     /// Liste von Flags zur Beschreibung der Block-Ausrichtung.
     /// </summary>
     [Flags]
-    public enum OrientationFlags
+    public enum OrientationFlags : byte
     {
         None,
 


### PR DESCRIPTION
Standardmäßig sind enums ein int. Die OrientationFalgs passen aber in ein byte.