### PR TITLE
[Hotfix] ChunkLoader Chunks freigeben

### DIFF
--- a/OctoAwesome/OctoAwesome/ChunkCache.cs
+++ b/OctoAwesome/OctoAwesome/ChunkCache.cs
@@ -11,11 +11,15 @@ namespace OctoAwesome
 
         private const int LimitX = 5;
         private const int LimitY = 5;
-        //private const int ZLimit = 5;
+        private const int LimitZ = 5;
 
-        private const int XMask = 31;
-        private const int YMask = 31;
-        private const int ZMask = 31;
+        private const int XMask = (1 << LimitX ) - 1;
+        private const int YMask = (1 << LimitY) - 1;
+        private const int ZMask = (1 << LimitZ) - 1;
+
+        public const int RangeX = (1 << LimitX - 1);
+        public const int RangeY = (1 << LimitY - 1);
+        public const int RangeZ = (1 << LimitZ - 1);
 
 
         public ChunkCache(Func<Index3, IChunk> loadDelegate, Action<Index3, IChunk> saveDelegate)

--- a/OctoAwesome/OctoAwesome/ChunkLoader.cs
+++ b/OctoAwesome/OctoAwesome/ChunkLoader.cs
@@ -39,6 +39,23 @@ namespace OctoAwesome
         {
             _cache.EnsureLoaded(_center);
 
+            for (int i = 0; i < ChunkCache.RangeX; i++)
+                for (int j = 0; j < ChunkCache.RangeY; j++)
+                    for (int k = 0; k < ChunkCache.RangeZ; k++)
+                    {
+                        if (i < _maxRange && j < _maxRange && k < _maxRange)
+                            continue;
+
+                        _cache.Release(_center.X + i, _center.Y + j, _center.Z + k);
+                        _cache.Release(_center.X + i, _center.Y - j, _center.Z + k);
+                        _cache.Release(_center.X - i, _center.Y + j, _center.Z + k);
+                        _cache.Release(_center.X - i, _center.Y - j, _center.Z + k);
+                        _cache.Release(_center.X + i, _center.Y + j, _center.Z - k);
+                        _cache.Release(_center.X + i, _center.Y - j, _center.Z - k);
+                        _cache.Release(_center.X - i, _center.Y + j, _center.Z - k);
+                        _cache.Release(_center.X - i, _center.Y - j, _center.Z - k);
+                    }
+
             for (int range = 1; range < _maxRange; range ++) 
                  for (int i = 0; i <= range; i++) 
                      for (int j = 0; j <= range; j++)


### PR DESCRIPTION
Wir haben bei unserer Performance-Session vor 14 Tagen vergessen, dass der ChunkLoader nicht mehr benötigte Chunks wieder freigibt. Andernfalls wiederholen sich die Chunks, wenn man eine Weile in eine Richtung läuft.