### PR TITLE
UIMod & Action API

### DIFF
--- a/OctoAwesome/OctoAwesome.Client/Components/ScreenComponent.cs
+++ b/OctoAwesome/OctoAwesome.Client/Components/ScreenComponent.cs
@@ -11,10 +11,13 @@ namespace OctoAwesome.Client.Components
 
         public CameraComponent Camera { get; private set; }
 
-        public ScreenComponent(Game game, PlayerComponent player, CameraComponent camera) : base(game)
+        public ActionManager ActionManager { get; private set; }
+
+        public ScreenComponent(Game game, PlayerComponent player, CameraComponent camera, ActionManager am) : base(game)
         {
             Player = player;
             Camera = camera;
+            ActionManager = am;
             TitlePrefix = "OctoAwesome";
         }
 

--- a/OctoAwesome/OctoAwesome.Client/OctoGame.cs
+++ b/OctoAwesome/OctoAwesome.Client/OctoGame.cs
@@ -63,6 +63,8 @@ namespace OctoAwesome.Client
             //simulation.UpdateOrder = 4;
             //Components.Add(simulation);
 
+            PluginManager.LoadPlugins();
+
             // Netzwerkspiel (Multiplayer)
             ClientComponent client = new ClientComponent(this);
             Components.Add(client);
@@ -75,14 +77,12 @@ namespace OctoAwesome.Client
             camera.UpdateOrder = 3;
             Components.Add(camera);
 
-            screens = new ScreenComponent(this, player, camera);
+            screens = new ScreenComponent(this, player, camera, PluginManager.ActionManager);
             screens.UpdateOrder = 1;
             screens.DrawOrder = 1;
             Components.Add(screens);
 
-            client.OnDisconnect += (message) => screens.NavigateToScreen(new DisconnectScreen(screens, message));
-
-            PluginManager.LoadPlugins();
+            client.OnDisconnect += (message) => screens.NavigateToScreen(new DisconnectScreen(screens, message));            
         }
 
         protected override void OnExiting(object sender, EventArgs args)

--- a/OctoAwesome/OctoAwesome.Client/OctoGame.cs
+++ b/OctoAwesome/OctoAwesome.Client/OctoGame.cs
@@ -81,6 +81,8 @@ namespace OctoAwesome.Client
             Components.Add(screens);
 
             client.OnDisconnect += (message) => screens.NavigateToScreen(new DisconnectScreen(screens, message));
+
+            PluginManager.LoadPlugins();
         }
 
         protected override void OnExiting(object sender, EventArgs args)

--- a/OctoAwesome/OctoAwesome.Client/Screens/MainScreen.cs
+++ b/OctoAwesome/OctoAwesome.Client/Screens/MainScreen.cs
@@ -75,6 +75,8 @@ namespace OctoAwesome.Client.Screens
             exitButton.Margin = new Border(0, 0, 0, 10);
             exitButton.LeftMouseClick += (s, e) => { manager.Exit(); };
             stack.Controls.Add(exitButton);
+
+            manager.ActionManager.Do("MainMenuAdd", new object[] { manager, stack.Controls });
         }
     }
 }

--- a/OctoAwesome/OctoAwesome.ModTestPlugin/OctoAwesome.ModTestPlugin.csproj
+++ b/OctoAwesome/OctoAwesome.ModTestPlugin/OctoAwesome.ModTestPlugin.csproj
@@ -1,87 +1,53 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{31D774C6-E5D9-40B7-8D63-942E28FE1D94}</ProjectGuid>
+    <ProjectGuid>{290EBCBD-45E0-42AA-8EC7-2E5E67B034E4}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>OctoAwesome.Runtime</RootNamespace>
-    <AssemblyName>OctoAwesome.Runtime</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <RootNamespace>OctoAwesome.ModTestPlugin</RootNamespace>
+    <AssemblyName>OctoAwesome.ModTestPlugin</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <SccProjectName>SAK</SccProjectName>
-    <SccLocalPath>SAK</SccLocalPath>
-    <SccAuxPath>SAK</SccAuxPath>
-    <SccProvider>SAK</SccProvider>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\bin\Debug\</OutputPath>
+    <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <UseVSHostingProcess>true</UseVSHostingProcess>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\bin\Release\</OutputPath>
+    <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="MonoGame.Framework, Version=3.4.0.459, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MonoGame.Framework.WindowsDX.3.4.0.459\lib\net40\MonoGame.Framework.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
-    <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.ServiceModel" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="ActorHost.cs" />
-    <Compile Include="ChunkConnection.cs" />
-    <Compile Include="ChunkDiskPersistence.cs" />
-    <Compile Include="ChunkSerializer.cs" />
-    <Compile Include="Client.cs" />
-    <Compile Include="ClientInfo.cs" />
-    <Compile Include="ConnectResult.cs" />
-    <Compile Include="DefinitionManager.cs" />
-    <Compile Include="ExtensionManager.cs" />
-    <Compile Include="IChunkConnection.cs" />
-    <Compile Include="IConnection.cs" />
-    <Compile Include="IConnectionCallback.cs" />
-    <Compile Include="IPlayerController.cs" />
-    <Compile Include="MapGeneratorManager.cs" />
-    <Compile Include="PluginManager.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="ResourceManager.cs" />
-    <Compile Include="Server.cs" />
-    <Compile Include="UpdateDomain.cs" />
-    <Compile Include="World.cs" />
+    <Compile Include="TestPlugin.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OctoAwesome\OctoAwesome.csproj">
       <Project>{93601db8-f134-418e-8b35-11e30cfec31c}</Project>
       <Name>OctoAwesome</Name>
-      <Private>False</Private>
     </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/OctoAwesome/OctoAwesome.ModTestPlugin/OctoAwesome.ModTestPlugin.csproj
+++ b/OctoAwesome/OctoAwesome.ModTestPlugin/OctoAwesome.ModTestPlugin.csproj
@@ -16,7 +16,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>..\bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -24,12 +24,16 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>..\bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="MonoGameUi, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\libs\MonoGameUi.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/OctoAwesome/OctoAwesome.ModTestPlugin/Properties/AssemblyInfo.cs
+++ b/OctoAwesome/OctoAwesome.ModTestPlugin/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// Allgemeine Informationen über eine Assembly werden über die folgenden 
+// Attribute gesteuert. Ändern Sie diese Attributwerte, um die Informationen zu ändern,
+// die einer Assembly zugeordnet sind.
+[assembly: AssemblyTitle("OctoAwesome.ModTestPlugin")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("OctoAwesome.ModTestPlugin")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Durch Festlegen von ComVisible auf "false" werden die Typen in dieser Assembly unsichtbar 
+// für COM-Komponenten.  Wenn Sie auf einen Typ in dieser Assembly von 
+// COM aus zugreifen müssen, sollten Sie das ComVisible-Attribut für diesen Typ auf "True" festlegen.
+[assembly: ComVisible(false)]
+
+// Die folgende GUID bestimmt die ID der Typbibliothek, wenn dieses Projekt für COM verfügbar gemacht wird
+[assembly: Guid("290ebcbd-45e0-42aa-8ec7-2e5e67b034e4")]
+
+// Versionsinformationen für eine Assembly bestehen aus den folgenden vier Werten:
+//
+//      Hauptversion
+//      Nebenversion 
+//      Buildnummer
+//      Revision
+//
+// Sie können alle Werte angeben oder die standardmäßigen Build- und Revisionsnummern 
+// übernehmen, indem Sie "*" eingeben:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/OctoAwesome/OctoAwesome.ModTestPlugin/TestPlugin.cs
+++ b/OctoAwesome/OctoAwesome.ModTestPlugin/TestPlugin.cs
@@ -19,7 +19,7 @@ namespace OctoAwesome.Basics
                 button.Margin = new Border(0, 0, 0, 10);
                 button.LeftMouseClick += (s, e) => { screenmanager.NavigateToScreen(new TestScreen(screenmanager)); };
                 controls.Add(button);
-            });
+            }, new[] { typeof(IScreenManager), typeof(IControlCollection) });
         }
     }
 

--- a/OctoAwesome/OctoAwesome.ModTestPlugin/TestPlugin.cs
+++ b/OctoAwesome/OctoAwesome.ModTestPlugin/TestPlugin.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OctoAwesome.Basics
+{
+    public class TestPlugin : IPlugin
+    {
+        public void OnLoaded()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/OctoAwesome/OctoAwesome.ModTestPlugin/TestPlugin.cs
+++ b/OctoAwesome/OctoAwesome.ModTestPlugin/TestPlugin.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using MonoGameUi;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -7,9 +8,33 @@ namespace OctoAwesome.Basics
 {
     public class TestPlugin : IPlugin
     {
-        public void OnLoaded()
+        public void OnLoaded(ActionManager manager)
         {
-            throw new NotImplementedException();
+            manager.Add("MainMenuAdd", (p) => 
+            {
+                var controls = (IControlCollection)p[1];
+                var screenmanager = (IScreenManager)p[0];
+                var button = Button.TextButton(screenmanager, "UIMods work!", "button");
+                button.HorizontalAlignment = HorizontalAlignment.Stretch;
+                button.Margin = new Border(0, 0, 0, 10);
+                button.LeftMouseClick += (s, e) => { screenmanager.NavigateToScreen(new TestScreen(screenmanager)); };
+                controls.Add(button);
+            });
+        }
+    }
+
+    public class TestScreen : Screen
+    {
+        public TestScreen(IScreenManager manager) : base(manager)
+        {
+            Padding = new Border(0, 0, 0, 0);
+
+            Button backButton = Button.TextButton(manager, "Back");
+            backButton.VerticalAlignment = VerticalAlignment.Top;
+            backButton.HorizontalAlignment = HorizontalAlignment.Left;
+            backButton.LeftMouseClick += (s, e) => { manager.NavigateBack(); };
+            backButton.Margin = new Border(10, 10, 10, 10);
+            Controls.Add(backButton);
         }
     }
 }

--- a/OctoAwesome/OctoAwesome.Runtime/PluginManager.cs
+++ b/OctoAwesome/OctoAwesome.Runtime/PluginManager.cs
@@ -9,15 +9,20 @@ namespace OctoAwesome.Runtime
     {
         private static List<IPlugin> plugins;
 
+        public static ActionManager ActionManager;
+
         public static IEnumerable<IPlugin> LoadPlugins()
         {
+            if (ActionManager == null)
+                ActionManager = new ActionManager();
+
             if (plugins == null)
             {
                 plugins = new List<IPlugin>();
                 plugins.AddRange(ExtensionManager.GetInstances<IPlugin>());
 
                 foreach (var plugin in plugins)
-                    plugin.OnLoaded();
+                    plugin.OnLoaded(ActionManager);
             }
 
             return plugins;

--- a/OctoAwesome/OctoAwesome.Runtime/PluginManager.cs
+++ b/OctoAwesome/OctoAwesome.Runtime/PluginManager.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OctoAwesome.Runtime
+{
+    public static class PluginManager
+    {
+        private static List<IPlugin> plugins;
+
+        public static IEnumerable<IPlugin> LoadPlugins()
+        {
+            if (plugins == null)
+            {
+                plugins = new List<IPlugin>();
+                plugins.AddRange(ExtensionManager.GetInstances<IPlugin>());
+
+                foreach (var plugin in plugins)
+                    plugin.OnLoaded();
+            }
+
+            return plugins;
+        }
+    }
+}

--- a/OctoAwesome/OctoAwesome.sln
+++ b/OctoAwesome/OctoAwesome.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OctoAwesome", "OctoAwesome\OctoAwesome.csproj", "{93601DB8-F134-418E-8B35-11E30CFEC31C}"
 EndProject
@@ -24,6 +24,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OctoAwesome.Server", "OctoAwesome.Server\OctoAwesome.Server.csproj", "{EF010D6F-4021-4358-A3F1-C436C952C02A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OctoAwesome.ModTestPlugin", "OctoAwesome.ModTestPlugin\OctoAwesome.ModTestPlugin.csproj", "{290EBCBD-45E0-42AA-8EC7-2E5E67B034E4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -55,6 +57,10 @@ Global
 		{EF010D6F-4021-4358-A3F1-C436C952C02A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EF010D6F-4021-4358-A3F1-C436C952C02A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EF010D6F-4021-4358-A3F1-C436C952C02A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{290EBCBD-45E0-42AA-8EC7-2E5E67B034E4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{290EBCBD-45E0-42AA-8EC7-2E5E67B034E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{290EBCBD-45E0-42AA-8EC7-2E5E67B034E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{290EBCBD-45E0-42AA-8EC7-2E5E67B034E4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/OctoAwesome/OctoAwesome/ActionManager.cs
+++ b/OctoAwesome/OctoAwesome/ActionManager.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OctoAwesome
+{
+    public class ActionManager
+    {
+        private Dictionary<string, Action<object[]>> actions;
+
+        public ActionManager()
+        {
+            actions = new Dictionary<string, Action<object[]>>();
+        }
+
+        public void Do(string actionName, object[] parameters)
+        {
+            foreach (var action in actions.Where(a => a.Key == actionName))
+                action.Value(parameters);
+        }
+
+        public void Add(string actioName, Action<object[]> action)
+        {
+            actions.Add(actioName, action);
+        }
+    }
+}

--- a/OctoAwesome/OctoAwesome/ActionManager.cs
+++ b/OctoAwesome/OctoAwesome/ActionManager.cs
@@ -10,11 +10,11 @@ namespace OctoAwesome
     /// </summary>
     public class ActionManager
     {
-        private Dictionary<string, Action<object[]>> actions;
+        private Dictionary<string, ActionInfo> actions;
         
         public ActionManager()
         {
-            actions = new Dictionary<string, Action<object[]>>();
+            actions = new Dictionary<string, ActionInfo>();
         }
 
         /// <summary>
@@ -25,7 +25,22 @@ namespace OctoAwesome
         public void Do(string actionName, object[] parameters)
         {
             foreach (var action in actions.Where(a => a.Key == actionName))
-                action.Value(parameters);
+            {
+                if (action.Value.Types.Length == parameters.Length)
+                {
+                    bool exit = false;
+                    for (int i = 0; i < parameters.Length; i++)
+                    {
+                        if (!action.Value.Types[i].IsInstanceOfType(parameters[i]))
+                        {
+                            exit = true;
+                            break;
+                        }
+                    }
+                    if (!exit)
+                        action.Value.Action(parameters);
+                }
+            }                
         }
 
         /// <summary>
@@ -33,9 +48,23 @@ namespace OctoAwesome
         /// </summary>
         /// <param name="actioName">Name der Aktion</param>
         /// <param name="action">Wird ausgeführt, wenn die Aktion ausgeführt wird</param>
-        public void Add(string actioName, Action<object[]> action)
+        /// <param name="types">Erwartete Typen der Parameter. Die Aktion wird nur ausgeführt, wenn diese Typen mit den Typen der Parameter übereinstimmen</param>
+        public void Add(string actioName, Action<object[]> action, Type[] types)
         {
-            actions.Add(actioName, action);
+            actions.Add(actioName, new ActionInfo(action, types));
         }
+    }
+
+    internal class ActionInfo
+    {
+        public ActionInfo(Action<object[]> action, Type[] types)
+        {
+            Action = action;
+            Types = types;
+        }
+
+        public Action<object[]> Action { get; set; }
+
+        public Type[] Types { get; set; }
     }
 }

--- a/OctoAwesome/OctoAwesome/ActionManager.cs
+++ b/OctoAwesome/OctoAwesome/ActionManager.cs
@@ -5,21 +5,34 @@ using System.Text;
 
 namespace OctoAwesome
 {
+    /// <summary>
+    /// Komponente im Pluginmodell: Ermöglicht simple Events zum Eingreifen in den Programmablauf
+    /// </summary>
     public class ActionManager
     {
         private Dictionary<string, Action<object[]>> actions;
-
+        
         public ActionManager()
         {
             actions = new Dictionary<string, Action<object[]>>();
         }
 
+        /// <summary>
+        /// Führt eine Aktion aus
+        /// </summary>
+        /// <param name="actionName">Name der auszuführenden Aktion</param>
+        /// <param name="parameters">Die Argumente, die an die Callbacks übergeben werden</param>
         public void Do(string actionName, object[] parameters)
         {
             foreach (var action in actions.Where(a => a.Key == actionName))
                 action.Value(parameters);
         }
 
+        /// <summary>
+        /// Registriert ein callback für eine Aktion
+        /// </summary>
+        /// <param name="actioName">Name der Aktion</param>
+        /// <param name="action">Wird ausgeführt, wenn die Aktion ausgeführt wird</param>
         public void Add(string actioName, Action<object[]> action)
         {
             actions.Add(actioName, action);

--- a/OctoAwesome/OctoAwesome/IPlugin.cs
+++ b/OctoAwesome/OctoAwesome/IPlugin.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OctoAwesome
+{
+    public interface IPlugin
+    {
+        void OnLoaded();
+    }
+}

--- a/OctoAwesome/OctoAwesome/IPlugin.cs
+++ b/OctoAwesome/OctoAwesome/IPlugin.cs
@@ -5,8 +5,15 @@ using System.Text;
 
 namespace OctoAwesome
 {
+    /// <summary>
+    /// Basisschnittstelle für eigene Plugins. Muss implemenetiert werden, damit Plugin erkannt wird.
+    /// </summary>
     public interface IPlugin
     {
+        /// <summary>
+        /// Wird einmal nach dem Laden des Plugins ausgeführt.
+        /// </summary>
+        /// <param name="manager">Der <see cref="ActionManager"/>, der verwendet werden kann, um Aktionen im Plugin zu registrieren</param>
         void OnLoaded(ActionManager manager);
     }
 }

--- a/OctoAwesome/OctoAwesome/IPlugin.cs
+++ b/OctoAwesome/OctoAwesome/IPlugin.cs
@@ -7,6 +7,6 @@ namespace OctoAwesome
 {
     public interface IPlugin
     {
-        void OnLoaded();
+        void OnLoaded(ActionManager manager);
     }
 }

--- a/OctoAwesome/OctoAwesome/OctoAwesome.csproj
+++ b/OctoAwesome/OctoAwesome/OctoAwesome.csproj
@@ -51,6 +51,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ActionManager.cs" />
     <Compile Include="Axis.cs" />
     <Compile Include="Block.cs" />
     <Compile Include="BlockDefinition.cs" />

--- a/OctoAwesome/OctoAwesome/OctoAwesome.csproj
+++ b/OctoAwesome/OctoAwesome/OctoAwesome.csproj
@@ -78,6 +78,7 @@
     <Compile Include="InventorySlot.cs" />
     <Compile Include="IPlanet.cs" />
     <Compile Include="ILocalChunkCache.cs" />
+    <Compile Include="IPlugin.cs" />
     <Compile Include="IResource.cs" />
     <Compile Include="IResourceDefinition.cs" />
     <Compile Include="IResourceManager.cs" />


### PR DESCRIPTION
Simple API (Quick & dirty mit object-Polymorphie) zum Modding der Benutzeroberfläche. Beispielhaft implementiert am Hauptmenü.

Folgende Klassen und Schnittstellen sind neu:
* `IPlugin`: Basisschnittstelle für Plugins
* `PluginManager`: verwaltet Plugins und ruft deren einzige Methode beim Start auf.
* `ActionManager`: Verwaltet Aktionen und führt diese aus.

Beispielimplementierung siehe `OctoAwesome.ModTestPlugin`.

Die Funktionweise mit object[] als Parameter ist nicht wirklich gut, aber MonoGameUi ist im OctoAwesome-Projekt nicht bekannt. Durch die Typüberprüfung werden aber trotzdem Casts zu falschen Typen (auf Grund von Plugin-Fehlern) recht gut unterbunden.