### PR TITLE
Beispiel Implementierung eines InputManagers

### DIFF
--- a/OctoAwesome/OctoAwesome.Client/Components/InputManager.cs
+++ b/OctoAwesome/OctoAwesome.Client/Components/InputManager.cs
@@ -63,7 +63,8 @@ namespace OctoAwesome.Client.Components
             KeyboardState state = Keyboard.GetState();
             foreach (Keys key in state.GetPressedKeys())
             {
-                bindings.FirstOrDefault(b => b.Value.key == key).Value.action();
+                if(bindings.Any(b => b.Value.key == key))
+                    bindings.FirstOrDefault(b => b.Value.key == key).Value.action();
             }
         }
     }

--- a/OctoAwesome/OctoAwesome.Client/Components/InputManager.cs
+++ b/OctoAwesome/OctoAwesome.Client/Components/InputManager.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Xna.Framework.Input;
+
+namespace OctoAwesome.Client.Components
+{
+    public class InputManager
+    {
+        #region Singleton
+
+        private static InputManager _instance;
+
+        public static InputManager Instance
+        {
+            get
+            {
+                if(_instance == null)
+                    _instance = new InputManager();
+                return _instance;
+            }
+        }
+
+        #endregion
+
+        private Dictionary<string, KeyBinding> bindings; 
+
+        private InputManager()
+        {
+            bindings = new Dictionary<string, KeyBinding>();
+        }
+
+        public void AddBinding(string name, Keys key, Action callback)
+        {
+            if(bindings.ContainsKey(name))
+                throw new Exception("name already registered");
+
+            KeyBinding newBinding = new KeyBinding();
+            newBinding.key = key;
+            newBinding.action = callback;
+
+            bindings.Add(name, newBinding);
+        }
+
+        public void RemoveBinding(string name)
+        {
+            if (!bindings.ContainsKey(name))
+                return;
+
+            bindings.Remove(name);
+        }
+
+        public void ChangeKey(string name, Keys key)
+        {
+            if (!bindings.ContainsKey(name))
+                throw new Exception("no matching binding found");
+
+            bindings[name].key = key;
+        }
+
+        public void UpdateInput()
+        {
+            KeyboardState state = Keyboard.GetState();
+            foreach (Keys key in state.GetPressedKeys())
+            {
+                bindings.FirstOrDefault(b => b.Value.key == key).Value.action();
+            }
+        }
+    }
+
+    class KeyBinding
+    {
+        public Keys key;
+        public Action action;
+    }
+}

--- a/OctoAwesome/OctoAwesome.Client/OctoAwesome.Client.csproj
+++ b/OctoAwesome/OctoAwesome.Client/OctoAwesome.Client.csproj
@@ -49,6 +49,7 @@
     <Compile Include="Components\ChunkRenderer.cs" />
     <Compile Include="Components\CameraComponent.cs" />
     <Compile Include="Components\ClientComponent.cs" />
+    <Compile Include="Components\InputManager.cs" />
     <Compile Include="Components\PlayerComponent.cs" />
     <Compile Include="Components\ScreenComponent.cs" />
     <Compile Include="Components\SimulationComponent.cs" />

--- a/OctoAwesome/OctoAwesome.Client/OctoGame.cs
+++ b/OctoAwesome/OctoAwesome.Client/OctoGame.cs
@@ -81,6 +81,14 @@ namespace OctoAwesome.Client
             Components.Add(screens);
 
             client.OnDisconnect += (message) => screens.NavigateToScreen(new DisconnectScreen(screens, message));
+
+            InputManager.Instance.AddBinding("toggleFullscreen", Keys.F11, new Action(graphics.ToggleFullScreen));
+        }
+
+        protected override void Update(GameTime gameTime)
+        {
+            InputManager.Instance.UpdateInput();
+            base.Update(gameTime);
         }
 
         protected override void OnExiting(object sender, EventArgs args)


### PR DESCRIPTION
Hab mal einen einfachen InputManager implementiert.
Es lassen sich KeyBindings mit einem Namen, Key und einer Action registrieren. 
Der Name fungiert als ID um auf das Binding zuzugreifen und es zu bearbeiten. 
Bei einem Keypress wird überprüft ob ein passendes Binding existiert, wenn ja wird die zugehörige Action aufgerufen.

Als Beispiel hab ich mal das Toggeln des FullscreenMode in OctoGame.cs mit F11 implementiert.
ACHTUNG: Aufgrund des MonogameUI Bugs lassen sich die Buttons nicht bedienen...

Wichtig wäre später noch eine Sache: Schon beim Start des Spiels MÜSSEN alle Bindings registriert werden, Actions können auch später hinzugefügt werden. Dies ist nötig damit der Input Tab in den Settings alle Bindings anzeigen kann ohne dass davor alle Komponenten geladen werden müssen.

Außerdem sollte der InputManager die Bindings in ein File speichern das beim starten gelesen wird.