### PR TITLE
Hilfedatei als xml generieren und Warnungen bzgl. fehlender Dokumentationskommentare unterdrücken

### DIFF
--- a/OctoAwesome/OctoAwesome.Runtime/OctoAwesome.Runtime.csproj
+++ b/OctoAwesome/OctoAwesome.Runtime/OctoAwesome.Runtime.csproj
@@ -25,6 +25,8 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <UseVSHostingProcess>true</UseVSHostingProcess>
+    <DocumentationFile>..\bin\Debug\OctoAwesome.Runtime.XML</DocumentationFile>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/OctoAwesome/OctoAwesome/OctoAwesome.csproj
+++ b/OctoAwesome/OctoAwesome/OctoAwesome.csproj
@@ -26,6 +26,8 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <UseVSHostingProcess>true</UseVSHostingProcess>
+    <DocumentationFile>..\bin\Debug\OctoAwesome.XML</DocumentationFile>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
Sorry, habe ich beim letzten Pull Request vergessen. Sonst buildet die Hilfe nicht bzw. ohne Kommentare.