### PR TITLE
Bäume temperaturabhängig nicht setzen

### DIFF
--- a/OctoAwesome/OctoAwesome.Basics/Definitions/Blocks/GravelBlockDefinition.cs
+++ b/OctoAwesome/OctoAwesome.Basics/Definitions/Blocks/GravelBlockDefinition.cs
@@ -7,7 +7,7 @@ namespace OctoAwesome.Basics
     {
         public override string Name
         {
-            get { return Languages.OctoBasics.Greystone; }
+            get { return Languages.OctoBasics.Gravel; }
         }
 
         public override Bitmap Icon

--- a/OctoAwesome/OctoAwesome.Basics/Definitions/Blocks/SandBlockDefinition.cs
+++ b/OctoAwesome/OctoAwesome.Basics/Definitions/Blocks/SandBlockDefinition.cs
@@ -7,7 +7,7 @@ namespace OctoAwesome.Basics
     {
         public override string Name
         {
-            get { return Languages.OctoBasics.RedCotton; }
+            get { return Languages.OctoBasics.Sand; }
         }
 
         public override Bitmap Icon

--- a/OctoAwesome/OctoAwesome.Basics/Definitions/Trees/BirchTreeDefinition.cs
+++ b/OctoAwesome/OctoAwesome.Basics/Definitions/Trees/BirchTreeDefinition.cs
@@ -36,6 +36,16 @@ namespace OctoAwesome.Basics
             ushort ground = builder.GetBlock(0, 0, -1);
             if (ground == water) return;
 
+            if (planet is ComplexPlanet)
+            {                
+                var temp = ((ComplexPlanet)planet).ClimateMap.GetTemperature(new Index3(
+                    builder.GlobalChunkIndex.X * Chunk.CHUNKSIZE_X,
+                    builder.GlobalChunkIndex.Y * Chunk.CHUNKSIZE_Y,
+                    index.Z));
+                if (temp > 30)
+                    return;
+            }            
+
             Random rand = new Random(seed);
             int height = rand.Next(3, 7);
             int radius = rand.Next(3, height);

--- a/OctoAwesome/OctoAwesome.Basics/Definitions/Trees/OakTreeDefinition.cs
+++ b/OctoAwesome/OctoAwesome.Basics/Definitions/Trees/OakTreeDefinition.cs
@@ -36,6 +36,16 @@ namespace OctoAwesome.Basics
             ushort ground = builder.GetBlock(0, 0, -1);
             if (ground == water) return;
 
+            if (planet is ComplexPlanet)
+            {
+                var temp = ((ComplexPlanet)planet).ClimateMap.GetTemperature(new Index3(
+                    builder.GlobalChunkIndex.X * Chunk.CHUNKSIZE_X,
+                    builder.GlobalChunkIndex.Y * Chunk.CHUNKSIZE_Y,
+                    index.Z));
+                if (temp > 27)
+                    return;
+            }
+
             Random rand = new Random(seed);
             int height = rand.Next(6, 10);
             int radius = rand.Next(3, height - 2);

--- a/OctoAwesome/OctoAwesome.Basics/Definitions/Trees/SpruceTreeDefinition.cs
+++ b/OctoAwesome/OctoAwesome.Basics/Definitions/Trees/SpruceTreeDefinition.cs
@@ -36,6 +36,13 @@ namespace OctoAwesome.Basics
             ushort ground = builder.GetBlock(0, 0, -1);
             if (ground == water) return;
 
+            var temp = ((ComplexPlanet)planet).ClimateMap.GetTemperature(new Index3(
+                builder.GlobalChunkIndex.X * Chunk.CHUNKSIZE_X,
+                builder.GlobalChunkIndex.Y * Chunk.CHUNKSIZE_Y,
+                index.Z));
+            if (temp > 25)
+                return;
+
             Random rand = new Random(seed);
             int height = rand.Next(3, 5);
             int radius = rand.Next(3, height);

--- a/OctoAwesome/OctoAwesome/LocalBuilder.cs
+++ b/OctoAwesome/OctoAwesome/LocalBuilder.cs
@@ -9,6 +9,8 @@
 
         private IChunkColumn column00, column01, column10, column11;
 
+        public Index2 GlobalChunkIndex { get; private set; }
+
         /// <summary>
         /// Erzeugt eine neue Instanz der Klasse LocalBuilder
         /// </summary>
@@ -29,6 +31,8 @@
             this.column01 = column01;
             this.column10 = column10;
             this.column11 = column11;
+
+            this.GlobalChunkIndex = column00.Index;
         }
 
         /// <summary>


### PR DESCRIPTION
**ACHTUNG** Dies ist nicht unbedingt die beste Lösung für das Problem (Quick&Dirty).

Änderungen:
* Der `LocalBuilder` bekommt einen GlobalChunkIndex aus `column00`.
* Die `TreeDefinitions` fragen über diesen Index die Temperatur über den Planeten ab.

Wenn nicht gemerged, bitte trotzdem BlockDefinitions für Sand und Gravel anpassen: im `Name`-Getter die richtige Lokalisierung verwenden.