### PR TITLE
Bäume temperaturabhängig setzen

### DIFF
--- a/OctoAwesome/OctoAwesome.Basics/Definitions/Trees/BirchTreeDefinition.cs
+++ b/OctoAwesome/OctoAwesome.Basics/Definitions/Trees/BirchTreeDefinition.cs
@@ -19,6 +19,22 @@ namespace OctoAwesome.Basics
             }
         }
 
+        public override float MaxTemperature
+        {
+            get
+            {
+                return 30;
+            }
+        }
+
+        public override float MinTemperature
+        {
+            get
+            {
+                return -5;
+            }
+        }
+
         public override int GetDensity(IPlanet planet, Index3 index)
         {
             return 4;

--- a/OctoAwesome/OctoAwesome.Basics/Definitions/Trees/OakTreeDefinition.cs
+++ b/OctoAwesome/OctoAwesome.Basics/Definitions/Trees/OakTreeDefinition.cs
@@ -19,6 +19,22 @@ namespace OctoAwesome.Basics
             }
         }
 
+        public override float MaxTemperature
+        {
+            get
+            {
+                return 27; 
+            }
+        }
+
+        public override float MinTemperature
+        {
+            get
+            {
+                return -5;
+            }
+        }
+
         public override void Init(IDefinitionManager definitionManager)
         {
             wood = definitionManager.GetBlockDefinitionIndex<WoodBlockDefinition>();

--- a/OctoAwesome/OctoAwesome.Basics/Definitions/Trees/SpruceTreeDefinition.cs
+++ b/OctoAwesome/OctoAwesome.Basics/Definitions/Trees/SpruceTreeDefinition.cs
@@ -19,6 +19,22 @@ namespace OctoAwesome.Basics
             }
         }
 
+        public override float MaxTemperature
+        {
+            get
+            {
+                return 25;
+            }
+        }
+
+        public override float MinTemperature
+        {
+            get
+            {
+                return -5;
+            }
+        }
+
         public override int GetDensity(IPlanet planet, Index3 index)
         {
             return 4;

--- a/OctoAwesome/OctoAwesome.Basics/ITreeDefinition.cs
+++ b/OctoAwesome/OctoAwesome.Basics/ITreeDefinition.cs
@@ -9,6 +9,10 @@ namespace OctoAwesome.Basics
     {
         int Order { get; }
 
+        float MaxTemperature { get; }
+
+        float MinTemperature { get; }
+
         void Init(IDefinitionManager definitionManager);
 
         int GetDensity(IPlanet planet, Index3 index);

--- a/OctoAwesome/OctoAwesome.Basics/TreeDefinition.cs
+++ b/OctoAwesome/OctoAwesome.Basics/TreeDefinition.cs
@@ -9,6 +9,10 @@ namespace OctoAwesome.Basics
     {
         public abstract int Order { get; }
 
+        public abstract float MaxTemperature { get; }
+
+        public abstract float MinTemperature { get; }
+
         public abstract int GetDensity(IPlanet planet, Index3 index);
 
         public abstract void Init(IDefinitionManager definitionManager);

--- a/OctoAwesome/OctoAwesome.Basics/TreePopulator.cs
+++ b/OctoAwesome/OctoAwesome.Basics/TreePopulator.cs
@@ -47,14 +47,20 @@ namespace OctoAwesome.Basics
             foreach (var treeDefinition in treeDefinitions)
             {
                 int density = treeDefinition.GetDensity(planet, sample);
-                if (density <= 0) continue;
+                if (density <= 0) continue;               
 
                 for (int i = 0; i < density; i++)
                 {
                     int x = random.Next(Chunk.CHUNKSIZE_X / 2, Chunk.CHUNKSIZE_X * 3 / 2);
                     int y = random.Next(Chunk.CHUNKSIZE_Y / 2, Chunk.CHUNKSIZE_Y * 3 / 2);
                     int z = LocalBuilder.GetSurfaceHeight(column00, column10, column01, column11, x, y);
-                    
+
+                    float blocktemp = planet.ClimateMap.GetTemperature(new Index3(column00.Index.X * Chunk.CHUNKSIZE_X,
+                    column00.Index.Y * Chunk.CHUNKSIZE_X, z));
+
+                    if (blocktemp > treeDefinition.MaxTemperature || blocktemp < treeDefinition.MinTemperature)
+                        continue;
+
                     LocalBuilder builder = new LocalBuilder(x, y, z + 1, column00, column10, column01, column11);
                     treeDefinition.PlantTree(definitionManager, planet, new Index3(x, y, z), builder, random.Next(int.MaxValue));
                 }


### PR DESCRIPTION
Zweiter Ansatz für temperaturabhängige Bäume.

Es gab wieder inkonsistente Zeilenenden (habs aber weggeklickt). Das heißt übrigens nicht, dass nur LF statt CRLF verwendet wird, sondern dass innerhalb der Datei gemischt wird. Anscheinend hat VS so seine Probleme mit Dateien mit LF und fügt dann neue Zeilen mit CRLF hinzu (und meckert später dann):
![Screenshot](https://cloud.githubusercontent.com/assets/10050780/14204008/945f97de-f801-11e5-8604-cae7e4e979bf.JPG)

Gestern haben wir uns ja auf CRLF als Lineending geeinigt. Bei git gibt es jetzt zwei Möglichkeiten:

1. Alle (!) schalten mit `git config core.autocrlf false` die automatische Konvertierung aus, du gehts alle Dateien durch und konvertierst sie zu CRLF und commitest dann. Git macht dann keine automatischen Veränderungen an den Zeilenenden und alle haben nur CRLF Dateien. Problem: Wenn einer von Linux commitet und eine LF Datei eincheckt, dann bekommen alle Windows Nutzer wieder Probleme (die man dann wieder lösen muss, wie oben beschrieben).
1. Oder wir halten im Repository alles mit LF und checken auf Windows mit automatischer Konvertierung zu CRLF (und beim Commit wieder zurück) aus (`git config core.autocrlf true`). Dann können auch die, die unter Linux arbeiten mit ihren LFs arbeiten. Aber alle (!), die unter Windows arbeiten, müssen dann natürlich auch die Einstellung so haben.

Mir erscheint die zweite Lösung besser.