### PR TITLE
Verbesserung bei der Teleportation

### DIFF
--- a/OctoAwesome/OctoAwesome.Client/Languages/OctoClient.Designer.cs
+++ b/OctoAwesome/OctoAwesome.Client/Languages/OctoClient.Designer.cs
@@ -19,7 +19,7 @@ namespace OctoAwesome.Client.Languages {
     // -Klasse über ein Tool wie ResGen oder Visual Studio automatisch generiert.
     // Um einen Member hinzuzufügen oder zu entfernen, bearbeiten Sie die .ResX-Datei und führen dann ResGen
     // mit der /str-Option erneut aus, oder Sie erstellen Ihr VS-Projekt neu.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class OctoClient {
@@ -372,6 +372,15 @@ namespace OctoAwesome.Client.Languages {
         internal static string Pixels {
             get {
                 return ResourceManager.GetString("Pixels", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Sucht eine lokalisierte Zeichenfolge, die Planet ähnelt.
+        /// </summary>
+        internal static string Planet {
+            get {
+                return ResourceManager.GetString("Planet", resourceCulture);
             }
         }
         

--- a/OctoAwesome/OctoAwesome.Client/Languages/OctoClient.de.resx
+++ b/OctoAwesome/OctoAwesome.Client/Languages/OctoClient.de.resx
@@ -279,4 +279,7 @@
   <data name="Up" xml:space="preserve">
     <value>Nach oben</value>
   </data>
+  <data name="Planet" xml:space="preserve">
+    <value>Planet</value>
+  </data>
 </root>

--- a/OctoAwesome/OctoAwesome.Client/Languages/OctoClient.resx
+++ b/OctoAwesome/OctoAwesome.Client/Languages/OctoClient.resx
@@ -281,4 +281,7 @@
   <data name="Up" xml:space="preserve">
     <value>Up</value>
   </data>
+  <data name="Planet" xml:space="preserve">
+    <value>Planet</value>
+  </data>
 </root>

--- a/OctoAwesome/OctoAwesome.Client/Screens/GameScreen.cs
+++ b/OctoAwesome/OctoAwesome.Client/Screens/GameScreen.cs
@@ -269,10 +269,10 @@ namespace OctoAwesome.Client.Screens
             Manager.Game.KeyMapper.AddAction("octoawesome:teleport", type =>
             {
                 if (!IsActiveScreen || type != KeyMapper.KeyType.Down) return;
-                Manager.NavigateToScreen(new TargetScreen(Manager, (x, y) => {
-                        Manager.Game.Player.Position.Position = new Coordinate(0, new Index3(x, y, 300), new Vector3());
-                        Manager.NavigateBack();
-                    }, Manager.Game.Player.Position.Position.GlobalBlockIndex.X, Manager.Game.Player.Position.Position.GlobalBlockIndex.Y));
+                Manager.NavigateToScreen(new TargetScreen(Manager, (coordinate) => {
+                    Manager.Game.Player.Position.Position = coordinate;
+                    Manager.NavigateBack();
+                }, Manager.Game.Player.Position.Position));
             });
         }
 

--- a/OctoAwesome/OctoAwesome.Client/Screens/TargetScreen.cs
+++ b/OctoAwesome/OctoAwesome.Client/Screens/TargetScreen.cs
@@ -10,7 +10,7 @@ namespace OctoAwesome.Client.Screens
     {
         private AssetComponent assets;
 
-        public TargetScreen(ScreenComponent manager, Action<int, int> tp, int x, int y) : base(manager)
+        public TargetScreen(ScreenComponent manager, Action<Coordinate> tp, Coordinate position) : base(manager)
         {
             assets = manager.Game.Assets;
 
@@ -43,6 +43,23 @@ namespace OctoAwesome.Client.Screens
             vstack.Orientation = Orientation.Vertical;
             spanel.Controls.Add(vstack);
 
+            StackPanel pStack = new StackPanel(manager);
+            pStack.Orientation = Orientation.Horizontal;
+            vstack.Controls.Add(pStack);
+
+            Label pLabel = new Label(manager);
+            pLabel.Text = Languages.OctoClient.Planet + ":";
+            pStack.Controls.Add(pLabel);
+
+            Textbox pText = new Textbox(manager)
+            {
+                Background = new BorderBrush(Color.Gray),
+                Width = 150,
+                Margin = new Border(2, 10, 2, 10),
+                Text = position.Planet.ToString()
+            };
+            pStack.Controls.Add(pText);
+
             StackPanel xStack = new StackPanel(manager);
             xStack.Orientation = Orientation.Horizontal;
             vstack.Controls.Add(xStack);
@@ -56,7 +73,7 @@ namespace OctoAwesome.Client.Screens
                 Background = new BorderBrush(Color.Gray),
                 Width = 150,
                 Margin = new Border(2, 10, 2, 10),
-                Text = x.ToString()
+                Text = position.GlobalBlockIndex.X.ToString()
             };
             xStack.Controls.Add(xText);
 
@@ -73,7 +90,7 @@ namespace OctoAwesome.Client.Screens
                 Background = new BorderBrush(Color.Gray),
                 Width = 150,
                 Margin = new Border(2, 10, 2, 10),
-                Text = y.ToString()
+                Text = position.GlobalBlockIndex.Y.ToString()
             };
             yStack.Controls.Add(yText);
 
@@ -81,10 +98,22 @@ namespace OctoAwesome.Client.Screens
             closeButton.HorizontalAlignment = HorizontalAlignment.Stretch;
             closeButton.LeftMouseClick += (s, e) =>
             {
-                if (tp != null)
-                    tp(int.Parse(xText.Text), int.Parse(yText.Text));
-                else
-                    manager.NavigateBack();
+                int planet = int.Parse(pText.Text);
+                int x = int.Parse(xText.Text);
+                int y = int.Parse(yText.Text);
+
+                var c = new LocalChunkCache(manager.Game.ResourceManager.GlobalChunkCache, false, 2, 1);
+                c.SetCenter(planet, new Index2(x, y), (b) =>
+                {
+                    var gl = c.GroundLevel(x, y);
+                    c.Flush();
+
+                    var coordinate = new Coordinate(planet, new Index3(x, y, gl + 2), new Vector3());
+                    if (tp != null)
+                        tp(coordinate);
+                    else
+                        manager.NavigateBack();
+                });
             };
             spanel.Controls.Add(closeButton);
 

--- a/OctoAwesome/OctoAwesome/ILocalChunkCache.cs
+++ b/OctoAwesome/OctoAwesome/ILocalChunkCache.cs
@@ -14,7 +14,7 @@ namespace OctoAwesome
         /// <param name="index">Die Koordinaten an der sich der Chunk befindet</param>
         /// <param name="successCallback">Routine die Aufgerufen werden soll, falls das setzen erfolgreich war oder nicht</param>
         bool SetCenter(IPlanet planet, Index2 index, Action<bool> successCallback = null);
-        
+
         /// <summary>
         /// Aktueller Planet auf dem sich der Cache bezieht.
         /// </summary>
@@ -101,7 +101,7 @@ namespace OctoAwesome
         int GetBlockMeta(Index3 index);
 
         /// <summary>
-        /// Ändert die Metadaten des Blockes an der angegebenen Koordinate. 
+        /// Ändert die Metadaten des Blockes an der angegebenen Koordinate.
         /// </summary>
         /// <param name="x">X-Anteil der Koordinate des Blocks innerhalb des Chunks</param>
         /// <param name="y">Y-Anteil der Koordinate des Blocks innerhalb des Chunks</param>
@@ -110,10 +110,18 @@ namespace OctoAwesome
         void SetBlockMeta(int x, int y, int z, int meta);
 
         /// <summary>
-        /// Ändert die Metadaten des Blockes an der angegebenen Koordinate. 
+        /// Ändert die Metadaten des Blockes an der angegebenen Koordinate.
         /// </summary>
         /// <param name="index">Block-Koordinate</param>
         /// <param name="meta">Die neuen Metadaten</param>
         void SetBlockMeta(Index3 index, int meta);
+
+        /// <summary>
+        /// Gibt das Höhenniveua der angegebenen Position zurück.
+        /// </summary>
+        /// <param name="x">Globale X-Koordinate in Blöcken.</param>
+        /// <param name="y">Globale Y-Koordinate in Blöcken.</param>
+        /// <returns>Git die Höhe in Blöcken zurück, oder -1 falls der zugehörige Chunk nicht geladen ist.</returns>
+        int GroundLevel(int x, int y);
     }
 }

--- a/OctoAwesome/OctoAwesome/LocalChunkCache.cs
+++ b/OctoAwesome/OctoAwesome/LocalChunkCache.cs
@@ -376,12 +376,15 @@ namespace OctoAwesome
             if (Planet == null)
                 return -1;
 
+            x = Index2.NormalizeAxis(x, Planet.Size.X);
+            y = Index2.NormalizeAxis(y, Planet.Size.Y);
+
             IChunkColumn column = chunkColumns[FlatIndex(x >> Chunk.LimitX, y >> Chunk.LimitY)];
 
             if (column == null)
                 return -1;
 
-            return column.Heights[((x & (Chunk.CHUNKSIZE_X - 1)) << Chunk.LimitX), ((y & (Chunk.CHUNKSIZE_Y - 1)) << Chunk.LimitY)];
+            return column.Heights[(x & (Chunk.CHUNKSIZE_X - 1)), (y & (Chunk.CHUNKSIZE_Y - 1))];
         }
     }
 }

--- a/OctoAwesome/OctoAwesome/LocalChunkCache.cs
+++ b/OctoAwesome/OctoAwesome/LocalChunkCache.cs
@@ -80,7 +80,7 @@ namespace OctoAwesome
         /// <param name="planetid">ID des Planet, auf dem sich der Chunk befindet</param>
         /// <param name="index">Die Koordinaten an der sich der Chunk befindet</param>
         /// <param name="successCallback">Routine die Aufgerufen werden soll, falls das setzen erfolgreich war oder nicht</param>
-        public bool SetCenter(int planetid, Index2 index, Action<bool> successCallback = null) 
+        public bool SetCenter(int planetid, Index2 index, Action<bool> successCallback = null)
             => SetCenter(globalCache.GetPlanet(planetid), index, successCallback);
 
         /// <summary>
@@ -214,7 +214,7 @@ namespace OctoAwesome
         /// </summary>
         /// <param name="index">Chunk Index</param>
         /// <returns>Instanz des Chunks</returns>
-        public IChunk GetChunk(Index3 index) 
+        public IChunk GetChunk(Index3 index)
             => GetChunk(index.X, index.Y, index.Z);
 
         /// <summary>
@@ -245,7 +245,7 @@ namespace OctoAwesome
         /// </summary>
         /// <param name="index">Block Index</param>
         /// <returns>Die Block-ID an der angegebenen Koordinate</returns>
-        public ushort GetBlock(Index3 index) 
+        public ushort GetBlock(Index3 index)
             => GetBlock(index.X, index.Y, index.Z);
 
         /// <summary>
@@ -270,7 +270,7 @@ namespace OctoAwesome
         /// </summary>
         /// <param name="index">Block-Koordinate</param>
         /// <param name="block">Die neue Block-ID.</param>
-        public void SetBlock(Index3 index, ushort block) 
+        public void SetBlock(Index3 index, ushort block)
             => SetBlock(index.X, index.Y, index.Z, block);
 
         /// <summary>
@@ -310,11 +310,11 @@ namespace OctoAwesome
         /// </summary>
         /// <param name="index">Block-Koordinate</param>
         /// <returns>Die Metadaten des angegebenen Blocks</returns>
-        public int GetBlockMeta(Index3 index) 
+        public int GetBlockMeta(Index3 index)
             => GetBlockMeta(index.X, index.Y, index.Z);
 
         /// <summary>
-        /// Ändert die Metadaten des Blockes an der angegebenen Koordinate. 
+        /// Ändert die Metadaten des Blockes an der angegebenen Koordinate.
         /// </summary>
         /// <param name="x">X-Anteil der Koordinate des Blocks innerhalb des Chunks</param>
         /// <param name="y">Y-Anteil der Koordinate des Blocks innerhalb des Chunks</param>
@@ -329,7 +329,7 @@ namespace OctoAwesome
         }
 
         /// <summary>
-        /// Ändert die Metadaten des Blockes an der angegebenen Koordinate. 
+        /// Ändert die Metadaten des Blockes an der angegebenen Koordinate.
         /// </summary>
         /// <param name="index">Block-Koordinate</param>
         /// <param name="meta">Die neuen Metadaten</param>
@@ -354,15 +354,34 @@ namespace OctoAwesome
         }
 
         /// <summary>
-        /// Gibt einen falchen Index um auf das Array <see cref="chunkColumns"/> zu zu greiffen
+        /// Gibt einen flachen Index um auf das Array <see cref="chunkColumns"/> zu zu greiffen
         /// </summary>
         /// <param name="x">Die X-Koordinate</param>
         /// <param name="y">Die Y-Koordinate</param>
         /// <returns>Der Abgeflachte index</returns>
-        private int FlatIndex(int x, int y) 
+        private int FlatIndex(int x, int y)
             => (((y & (mask)) << limit) | ((x & (mask))));
 
-        public IPlanet LoadPlanet(int id) 
+        public IPlanet LoadPlanet(int id)
             => globalCache.GetPlanet(id);
+
+        /// <summary>
+        /// Gibt das Höhenniveua der angegebenen Position zurück.
+        /// </summary>
+        /// <param name="x">Globale X-Koordinate in Blöcken.</param>
+        /// <param name="y">Globale Y-Koordinate in Blöcken.</param>
+        /// <returns>Git die Höhe in Blöcken zurück, oder -1 falls der zugehörige Chunk nicht geladen ist.</returns>
+        public int GroundLevel(int x, int y)
+        {
+            if (Planet == null)
+                return -1;
+
+            IChunkColumn column = chunkColumns[FlatIndex(x >> Chunk.LimitX, y >> Chunk.LimitY)];
+
+            if (column == null)
+                return -1;
+
+            return column.Heights[((x & (Chunk.CHUNKSIZE_X - 1)) << Chunk.LimitX), ((y & (Chunk.CHUNKSIZE_Y - 1)) << Chunk.LimitY)];
+        }
     }
 }


### PR DESCRIPTION
Dies sind die ersten Änderungen aus meinem "Multiplanet"-Versuch und sind die Basis, um überhaupt zwischen Planeten wechseln zu können.

Änderungen im Detail:
* Auswahlfeld für Planeten im TargetScreen
* Setzen der neuen Position nicht mehr auf Basis von nur Koordinaten, sondern einer richtigen `Coordinate`
* Neue Methode im `LocalChunkCache`, um die maximale z-Zöhe an einer bestimmten Position (x, y) zu ermitteln (`ChunkColumn.Heights` auf höherer Ebene)
* Beim Teleport wird nun knapp über dem Bodenniveau gespawnt

Fragen an die Performance-Fraktion:
* Ist die Verwendung des LocalChunkCaches im `TargetScreen` so OK, also wird auch anschließend alles korrekt wieder freigegeben? Ich bin nicht mehr so ganz in unserem Caching drin...