### PR TITLE
Adds OpenAL redistributables

### DIFF
--- a/OctoAwesome/OctoAwesome.Client/OctoAwesome.Client.csproj
+++ b/OctoAwesome/OctoAwesome.Client/OctoAwesome.Client.csproj
@@ -40,6 +40,7 @@
     <PackageReference Include="engenious.ContentTool" Version="0.5.1.11-alpha" />
     <PackageReference Include="engenious.UI" Version="0.5.1.1-alpha" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="OpenAL.Soft" Version="1.19.1" Condition="$(RuntimeIdentifier.StartsWith('win')) Or ('$(RuntimeIdentifier)' == '' AND $([MSBuild]::IsOSPlatform('Windows')))"/>
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
     <PackageReference Include="System.IO" Version="4.3.0" />
     <PackageReference Include="System.IO.Compression" Version="4.3.0" />


### PR DESCRIPTION
With this change user who want to contribute or just want to play the artifacts on windows do not need to install OpenAL. OpenAL will be present as a runtime library.

The nuget package used does not have dlls for linux. @jvbsl wants to make a better and more bulletproof solution in engenious for all supported plattforms in the near future.